### PR TITLE
Namespacing and refactoring

### DIFF
--- a/css/grid.css
+++ b/css/grid.css
@@ -35,7 +35,8 @@
 	Uses $cg-default-size-prefix and sets the defaults for browsers that don't support media queries. */
 .grid {
   padding-left: 0px;
-  padding-right: 0px; }
+  padding-right: 0px;
+  width: 760px; }
 
 .c1, .c2, .c3, .c4, .c5, .c6, .c7, .c8, .c9, .c10, .c11, .c12,
 .c1-2, .c2-3, .c3-4, .c4-5, .c5-6, .c6-7, .c7-8, .c8-9, .c9-10, .c10-11, .c11-12,
@@ -166,7 +167,8 @@
 @media only screen and (min-width: 1048px) {
   .grid {
     padding-left: 0px;
-    padding-right: 0px; }
+    padding-right: 0px;
+    width: 1048px; }
 
   .c1, .c2, .c3, .c4, .c5, .c6, .c7, .c8, .c9, .c10, .c11, .c12,
   .c1-2, .c2-3, .c3-4, .c4-5, .c5-6, .c6-7, .c7-8, .c8-9, .c9-10, .c10-11, .c11-12,

--- a/css/grid.css
+++ b/css/grid.css
@@ -11,14 +11,14 @@
  -------------------------------------------------- */
 /** grid foundation
  -------------------------------------------------- */
-.cg-grid {
+.grid {
   margin: 0 auto; }
 
 /* fluid media */
-.cg-row img,
-.cg-row object,
-.cg-row embed,
-.cg-row video {
+.row img,
+.row object,
+.row embed,
+.row video {
   max-width: 100%; }
 
 /** mixins
@@ -30,7 +30,7 @@
  */
 /* 	Default Grid
 	Uses $cg-default-size-prefix and sets the defaults for browsers that don't support media queries. */
-.cg-grid {
+.grid {
   padding-left: 20px;
   padding-right: 20px;
   width: 760px; }
@@ -154,7 +154,7 @@
 
 /* 	Accounts for extra margin on first column
 	This value should change a negative margin of whatever your gutter width is. */
-.cg-row {
+.row {
   margin-left: -20px; }
 
 /* 	Small Sized Grid
@@ -162,7 +162,7 @@
 /* 	Medium Sized Grid
 	Desktop sized columns. */
 @media only screen and (min-width: 1048px) {
-  .cg-grid {
+  .grid {
     padding-left: 0px;
     padding-right: 0px;
     width: 1048px; }
@@ -286,19 +286,19 @@
 
   /* 	Accounts for extra margin on first column
   	This value should change a negative margin of whatever your gutter width is. */
-  .cg-row {
+  .row {
     margin-left: -20px; } }
 /* 	Large Desktop Grid
 	Very wide columns for large monitors. */
 /* 	Single-column mobile
 	Get rid of widths and floats, go to fluid single column. */
 @media only screen and (max-width: 799px) {
-  .cg-grid {
+  .grid {
     padding-left: 10px;
     padding-right: 10px;
     width: auto; }
 
-  .cg-grid,
+  .grid,
   .c1, .c2, .c3, .c4, .c5, .c6, .c7, .c8, .c9, .c10, .c11, .c12,
   .c1-2, .c2-3, .c3-4, .c4-5, .c5-6, .c6-7, .c7-8, .c8-9, .c9-10, .c10-11, .c11-12,
   .c1-3, .c2-4, .c3-5, .c4-6, .c5-7, .c6-8, .c7-9, .c8-10, .c9-11, .c10-12,
@@ -316,7 +316,7 @@
     margin-left: 0;
     width: auto; }
 
-  .cg-row {
+  .row {
     margin-left: 0; } }
 /* Zeroing out leftmost nested .unit margins */
 [class*=c1] [class*=c1],
@@ -343,7 +343,7 @@
 [class*=c10-] .offset1:first-child,
 [class*=c11-] .offset1:first-child,
 [class*=c12-] .offset1:first-child,
-.cg-row .cg-row {
+.row .row {
   margin-left: 0; }
 
 /* Full-width  */
@@ -357,15 +357,15 @@
 /* Row offsetfix
 Uses variation of Nicolas Gallagher's Micro offsetfix.
 http://nicolasgallagher.com/micro-offsetfix-hack/ */
-.cg-row:before,
-.cg-row:after {
+.row:before,
+.row:after {
   content: "";
   display: table; }
 
-.cg-row:after {
+.row:after {
   clear: both; }
 
-.cg-row {
+.row {
   /* Just in case: make sure that rows offset outside floats. */
   clear: both;
   /* For IE 6/7 (trigger hasLayout) */

--- a/css/grid.css
+++ b/css/grid.css
@@ -24,6 +24,9 @@
 /** mixins
  -------------------------------------------------- */
 /**
+ * Prints a width definition to be used by .grid.
+ */
+/**
  * Generates the grid CSS for a given size prefix.
  *
  * This should be called within the media query associated with the size prefix.
@@ -31,9 +34,8 @@
 /* 	Default Grid
 	Uses $cg-default-size-prefix and sets the defaults for browsers that don't support media queries. */
 .grid {
-  padding-left: 20px;
-  padding-right: 20px;
-  width: 760px; }
+  padding-left: 0px;
+  padding-right: 0px; }
 
 .c1, .c2, .c3, .c4, .c5, .c6, .c7, .c8, .c9, .c10, .c11, .c12,
 .c1-2, .c2-3, .c3-4, .c4-5, .c5-6, .c6-7, .c7-8, .c8-9, .c9-10, .c10-11, .c11-12,
@@ -164,8 +166,7 @@
 @media only screen and (min-width: 1048px) {
   .grid {
     padding-left: 0px;
-    padding-right: 0px;
-    width: 1048px; }
+    padding-right: 0px; }
 
   .c1, .c2, .c3, .c4, .c5, .c6, .c7, .c8, .c9, .c10, .c11, .c12,
   .c1-2, .c2-3, .c3-4, .c4-5, .c5-6, .c6-7, .c7-8, .c8-9, .c9-10, .c10-11, .c11-12,
@@ -292,7 +293,7 @@
 	Very wide columns for large monitors. */
 /* 	Single-column mobile
 	Get rid of widths and floats, go to fluid single column. */
-@media only screen and (max-width: 799px) {
+@media only screen and (max-width: 759px) {
   .grid {
     padding-left: 10px;
     padding-right: 10px;

--- a/css/grid.css
+++ b/css/grid.css
@@ -11,14 +11,14 @@
  -------------------------------------------------- */
 /** grid foundation
  -------------------------------------------------- */
-.grid {
+.cg-grid {
   margin: 0 auto; }
 
 /* fluid media */
-.row img,
-.row object,
-.row embed,
-.row video {
+.cg-row img,
+.cg-row object,
+.cg-row embed,
+.cg-row video {
   max-width: 100%; }
 
 /** mixins
@@ -30,7 +30,7 @@
  */
 /* 	Default Grid
 	Uses $cg-default-size-prefix and sets the defaults for browsers that don't support media queries. */
-.grid {
+.cg-grid {
   padding-left: 20px;
   padding-right: 20px;
   width: 760px; }
@@ -154,7 +154,7 @@
 
 /* 	Accounts for extra margin on first column
 	This value should change a negative margin of whatever your gutter width is. */
-.row {
+.cg-row {
   margin-left: -20px; }
 
 /* 	Small Sized Grid
@@ -162,7 +162,7 @@
 /* 	Medium Sized Grid
 	Desktop sized columns. */
 @media only screen and (min-width: 1048px) {
-  .grid {
+  .cg-grid {
     padding-left: 0px;
     padding-right: 0px;
     width: 1048px; }
@@ -286,19 +286,19 @@
 
   /* 	Accounts for extra margin on first column
   	This value should change a negative margin of whatever your gutter width is. */
-  .row {
+  .cg-row {
     margin-left: -20px; } }
 /* 	Large Desktop Grid
 	Very wide columns for large monitors. */
 /* 	Single-column mobile
 	Get rid of widths and floats, go to fluid single column. */
 @media only screen and (max-width: 799px) {
-  .grid {
+  .cg-grid {
     padding-left: 10px;
     padding-right: 10px;
     width: auto; }
 
-  .grid,
+  .cg-grid,
   .c1, .c2, .c3, .c4, .c5, .c6, .c7, .c8, .c9, .c10, .c11, .c12,
   .c1-2, .c2-3, .c3-4, .c4-5, .c5-6, .c6-7, .c7-8, .c8-9, .c9-10, .c10-11, .c11-12,
   .c1-3, .c2-4, .c3-5, .c4-6, .c5-7, .c6-8, .c7-9, .c8-10, .c9-11, .c10-12,
@@ -316,7 +316,7 @@
     margin-left: 0;
     width: auto; }
 
-  .row {
+  .cg-row {
     margin-left: 0; } }
 /* Zeroing out leftmost nested .unit margins */
 [class*=c1] [class*=c1],
@@ -343,7 +343,7 @@
 [class*=c10-] .offset1:first-child,
 [class*=c11-] .offset1:first-child,
 [class*=c12-] .offset1:first-child,
-.row .row {
+.cg-row .cg-row {
   margin-left: 0; }
 
 /* Full-width  */
@@ -357,15 +357,15 @@
 /* Row offsetfix
 Uses variation of Nicolas Gallagher's Micro offsetfix.
 http://nicolasgallagher.com/micro-offsetfix-hack/ */
-.row:before,
-.row:after {
+.cg-row:before,
+.cg-row:after {
   content: "";
   display: table; }
 
-.row:after {
+.cg-row:after {
   clear: both; }
 
-.row {
+.cg-row {
   /* Just in case: make sure that rows offset outside floats. */
   clear: both;
   /* For IE 6/7 (trigger hasLayout) */

--- a/css/grid.css
+++ b/css/grid.css
@@ -7,7 +7,7 @@
  To provide your own values for the variables below, simply re-define them in your Sass prior
  to importing this partial. You can only customize variables that include the !default flag.
  -------------------------------------------------- */
-/** mixins
+/** move vars to a map for dynamic usage
  -------------------------------------------------- */
 /** grid foundation
  -------------------------------------------------- */
@@ -21,13 +21,19 @@
 .row video {
   max-width: 100%; }
 
-/* 	Default Desktop/Tablet Grid
-	Works fine with older browsers that don't support media queries. */
+/** mixins
+ -------------------------------------------------- */
+/**
+ * Generates the grid CSS for a given size prefix.
+ *
+ * This should be called within the media query associated with the size prefix.
+ */
+/* 	Default Grid
+	Uses $cg-default-size-prefix and sets the defaults for browsers that don't support media queries. */
 .grid {
-  /* this makes the page wide but keeps content away from the edge */
-  padding-left: 0px;
-  padding-right: 0px;
-  width: 1048px; }
+  padding-left: 20px;
+  padding-right: 20px;
+  width: 760px; }
 
 .c1, .c2, .c3, .c4, .c5, .c6, .c7, .c8, .c9, .c10, .c11, .c12,
 .c1-2, .c2-3, .c3-4, .c4-5, .c5-6, .c6-7, .c7-8, .c8-9, .c9-10, .c10-11, .c11-12,
@@ -41,17 +47,22 @@
 .c1-10, .c2-11, .c3-12,
 .c1-11, .c2-12,
 .c1-12 {
-  margin-left: 20px;
   display: inline;
+  /* IE6/IE7 double-margin float bug fix */
   float: left;
-  min-height: 1px; }
+  margin-left: 20px;
+  /* Prevent collapsing of empty columns. Min-height prevents collapse
+  everywhere but IE6. IE6 doesn't collapse empty collumns anyhow, so no need
+  for a fix there. */
+  min-height: 1px;
+  clear: none; }
 
 /* 	1/12 */
 .c1, .c2, .c3, .c4, .c5, .c6, .c7, .c8, .c9, .c10, .c11, .c12 {
-  width: 69px; }
+  width: 45px; }
 
 .offset1 {
-  margin-left: 109px; }
+  margin-left: 85px; }
 
 [class*=c1-] .offset1:first-child,
 [class*=c2-] .offset1:first-child,
@@ -65,94 +76,96 @@
 [class*=c10-] .offset1:first-child,
 [class*=c11-] .offset1:first-child,
 [class*=c12-] .offset1:first-child {
-  margin-left: 89px; }
+  margin-left: 65px; }
 
 /* 	2/12 */
 .c1-2, .c2-3, .c3-4, .c4-5, .c5-6, .c6-7, .c7-8, .c8-9, .c9-10, .c10-11, .c11-12 {
-  width: 158px; }
+  width: 110px; }
 
 .offset2 {
-  margin-left: 198px; }
+  margin-left: 150px; }
 
 /* 	3/12 */
 .c1-3, .c2-4, .c3-5, .c4-6, .c5-7, .c6-8, .c7-9, .c8-10, .c9-11, .c10-12 {
-  width: 247px; }
+  width: 175px; }
 
 .offset3 {
-  margin-left: 287px; }
+  margin-left: 215px; }
 
 /* 	4/12 */
 .c1-4, .c2-5, .c3-6, .c4-7, .c5-8, .c6-9, .c7-10, .c8-11, .c9-12 {
-  width: 336px; }
+  width: 240px; }
 
 .offset4 {
-  margin-left: 376px; }
+  margin-left: 280px; }
 
 /* 	5/12 */
 .c1-5, .c2-6, .c3-7, .c4-8, .c5-9, .c6-10, .c7-11, .c8-12 {
-  width: 425px; }
+  width: 305px; }
 
 .offset5 {
-  margin-left: 465px; }
+  margin-left: 345px; }
 
 /* 	6/12 */
 .c1-6, .c2-7, .c3-8, .c4-9, .c5-10, .c6-11, .c7-12 {
-  width: 514px; }
+  width: 370px; }
 
 .offset6 {
-  margin-left: 554px; }
+  margin-left: 410px; }
 
 /* 	7/12 */
 .c1-7, .c2-8, .c3-9, .c4-10, .c5-11, .c6-12 {
-  width: 603px; }
+  width: 435px; }
 
 .offset7 {
-  margin-left: 643px; }
+  margin-left: 475px; }
 
 /* 	8/12 */
 .c1-8, .c2-9, .c3-10, .c4-11, .c5-12 {
-  width: 692px; }
+  width: 500px; }
 
 .offset8 {
-  margin-left: 732px; }
+  margin-left: 540px; }
 
 /* 	9/12 */
 .c1-9, .c2-10, .c3-11, .c4-12 {
-  width: 781px; }
+  width: 565px; }
 
 .offset9 {
-  margin-left: 821px; }
+  margin-left: 605px; }
 
 /* 	10/12 */
 .c1-10, .c2-11, .c3-12 {
-  width: 870px; }
+  width: 630px; }
 
 .offset10 {
-  margin-left: 910px; }
+  margin-left: 670px; }
 
 /* 	11/12 */
 .c1-11, .c2-12 {
-  width: 959px; }
+  width: 695px; }
 
 .offset11 {
-  margin-left: 999px; }
+  margin-left: 735px; }
 
 /* 	12/12 */
 .c1-12 {
-  width: 1048px; }
+  width: 760px; }
 
 /* 	Accounts for extra margin on first column
-		This value should change a negative margin of whatever your gutter width is. */
+	This value should change a negative margin of whatever your gutter width is. */
 .row {
   margin-left: -20px; }
 
 /* 	Small Sized Grid
 	Tablet sized columns. */
-@media only screen and (min-width: 800px) and (max-width: 1047px) {
+/* 	Medium Sized Grid
+	Desktop sized columns. */
+@media only screen and (min-width: 1048px) {
   .grid {
-    padding-left: 20px;
-    padding-right: 20px;
-    width: 760px; }
+    padding-left: 0px;
+    padding-right: 0px;
+    width: 1048px; }
 
   .c1, .c2, .c3, .c4, .c5, .c6, .c7, .c8, .c9, .c10, .c11, .c12,
   .c1-2, .c2-3, .c3-4, .c4-5, .c5-6, .c6-7, .c7-8, .c8-9, .c9-10, .c10-11, .c11-12,
@@ -178,10 +191,10 @@
 
   /* 	1/12 */
   .c1, .c2, .c3, .c4, .c5, .c6, .c7, .c8, .c9, .c10, .c11, .c12 {
-    width: 45px; }
+    width: 69px; }
 
   .offset1 {
-    margin-left: 85px; }
+    margin-left: 109px; }
 
   [class*=c1-] .offset1:first-child,
   [class*=c2-] .offset1:first-child,
@@ -195,81 +208,81 @@
   [class*=c10-] .offset1:first-child,
   [class*=c11-] .offset1:first-child,
   [class*=c12-] .offset1:first-child {
-    margin-left: 65px; }
+    margin-left: 89px; }
 
   /* 	2/12 */
   .c1-2, .c2-3, .c3-4, .c4-5, .c5-6, .c6-7, .c7-8, .c8-9, .c9-10, .c10-11, .c11-12 {
-    width: 110px; }
+    width: 158px; }
 
   .offset2 {
-    margin-left: 150px; }
+    margin-left: 198px; }
 
   /* 	3/12 */
   .c1-3, .c2-4, .c3-5, .c4-6, .c5-7, .c6-8, .c7-9, .c8-10, .c9-11, .c10-12 {
-    width: 175px; }
+    width: 247px; }
 
   .offset3 {
-    margin-left: 215px; }
+    margin-left: 287px; }
 
   /* 	4/12 */
   .c1-4, .c2-5, .c3-6, .c4-7, .c5-8, .c6-9, .c7-10, .c8-11, .c9-12 {
-    width: 240px; }
+    width: 336px; }
 
   .offset4 {
-    margin-left: 280px; }
+    margin-left: 376px; }
 
   /* 	5/12 */
   .c1-5, .c2-6, .c3-7, .c4-8, .c5-9, .c6-10, .c7-11, .c8-12 {
-    width: 305px; }
+    width: 425px; }
 
   .offset5 {
-    margin-left: 345px; }
+    margin-left: 465px; }
 
   /* 	6/12 */
   .c1-6, .c2-7, .c3-8, .c4-9, .c5-10, .c6-11, .c7-12 {
-    width: 370px; }
+    width: 514px; }
 
   .offset6 {
-    margin-left: 410px; }
+    margin-left: 554px; }
 
   /* 	7/12 */
   .c1-7, .c2-8, .c3-9, .c4-10, .c5-11, .c6-12 {
-    width: 435px; }
+    width: 603px; }
 
   .offset7 {
-    margin-left: 475px; }
+    margin-left: 643px; }
 
   /* 	8/12 */
   .c1-8, .c2-9, .c3-10, .c4-11, .c5-12 {
-    width: 500px; }
+    width: 692px; }
 
   .offset8 {
-    margin-left: 540px; }
+    margin-left: 732px; }
 
   /* 	9/12 */
   .c1-9, .c2-10, .c3-11, .c4-12 {
-    width: 565px; }
+    width: 781px; }
 
   .offset9 {
-    margin-left: 605px; }
+    margin-left: 821px; }
 
   /* 	10/12 */
   .c1-10, .c2-11, .c3-12 {
-    width: 630px; }
+    width: 870px; }
 
   .offset10 {
-    margin-left: 670px; }
+    margin-left: 910px; }
 
   /* 	11/12 */
   .c1-11, .c2-12 {
-    width: 695px; }
+    width: 959px; }
 
   .offset11 {
-    margin-left: 735px; }
+    margin-left: 999px; }
 
   /* 	12/12 */
   .c1-12 {
-    width: 760px; }
+    width: 1048px; }
 
   /* 	Accounts for extra margin on first column
   	This value should change a negative margin of whatever your gutter width is. */

--- a/sass/grid.scss
+++ b/sass/grid.scss
@@ -9,6 +9,7 @@
  to importing this partial. You can only customize variables that include the !default flag.
  -------------------------------------------------- */
 $cg-use-lg-breakpoint: false !default;
+$cg-use-border-box: false !default;
 $cg-default-size-prefix: 'sm' !default; // formerly md
 
 // Large (large desktop) in px
@@ -52,9 +53,16 @@ $cg-xs-mq: '(max-width: #{$cg-xs-bp-max-width})' !default;
 $cg-column-count: 12;
 
 // Column widths (not overridable)
+// If we're using box-sizing:border-box, then we need to manually add the padding (gutters) to the inner-width
+// value to get an accurate column width.
 $cg-lg-column-width: (($cg-lg-grid-inner-width - (($cg-lg-col-margins * ($cg-column-count - 1)))) / $cg-column-count);
 $cg-md-column-width: (($cg-md-grid-inner-width - (($cg-md-col-margins * ($cg-column-count - 1)))) / $cg-column-count);
 $cg-sm-column-width: (($cg-sm-grid-inner-width - (($cg-sm-col-margins * ($cg-column-count - 1)))) / $cg-column-count);
+@if $cg-use-border-box {
+	$cg-lg-column-width: ((($cg-lg-grid-inner-width + ($cg-lg-grid-gutter * 2)) - (($cg-lg-col-margins * ($cg-column-count - 1)))) / $cg-column-count);
+	$cg-md-column-width: ((($cg-md-grid-inner-width + ($cg-md-grid-gutter * 2)) - (($cg-md-col-margins * ($cg-column-count - 1)))) / $cg-column-count);
+	$cg-sm-column-width: ((($cg-sm-grid-inner-width + ($cg-sm-grid-gutter * 2)) - (($cg-sm-col-margins * ($cg-column-count - 1)))) / $cg-column-count);
+}
 
 /** move vars to a map for dynamic usage
  -------------------------------------------------- */
@@ -117,7 +125,7 @@ $_cg-default-size-map: map-get($_cg-size-map, $cg-default-size-prefix);
 	padding-right: $gutter;
 }
 
-@mixin cg-width($col-width, $margin-width, $multiplier: 1) {
+@mixin cg-cols-width($col-width, $margin-width, $multiplier: 1) {
 	width: (($col-width * $multiplier) + (($multiplier - 1) * $margin-width));
 }
 
@@ -175,7 +183,12 @@ $_cg-default-size-map: map-get($_cg-size-map, $cg-default-size-prefix);
 		// --- The rest of the sizes use the routine below.
 		.grid {
 			@include cg-gutters(map-get($_map, grid-gutter));
-			width: map-get($_map, grid-inner-width);
+			// width: map-get($_map, grid-inner-width);
+			@if $cg-use-border-box {
+				width: map-get($_map, grid-inner-width) + (map-get($_map, grid-gutter) * 2);
+			} @else {
+				width: map-get($_map, grid-inner-width);
+			}
 		}
 		.c1,.c2,.c3,.c4,.c5,.c6,.c7,.c8,.c9,.c10,.c11,.c12,
 		.c1-2,.c2-3,.c3-4,.c4-5,.c5-6,.c6-7,.c7-8,.c8-9,.c9-10,.c10-11,.c11-12,
@@ -199,7 +212,7 @@ $_cg-default-size-map: map-get($_cg-size-map, $cg-default-size-prefix);
 			clear: none;
 		}
 		/* 	1/12 */
-		.c1,.c2,.c3,.c4,.c5,.c6,.c7,.c8,.c9,.c10,.c11,.c12 { @include cg-width(map-get($_map, column-width), map-get($_map, col-margins)); }
+		.c1,.c2,.c3,.c4,.c5,.c6,.c7,.c8,.c9,.c10,.c11,.c12 { @include cg-cols-width(map-get($_map, column-width), map-get($_map, col-margins)); }
 		.offset1 { @include cg-offset(map-get($_map, column-width), map-get($_map, col-margins)); }
 		[class*=c1-],
 		[class*=c2-],
@@ -218,37 +231,37 @@ $_cg-default-size-map: map-get($_cg-size-map, $cg-default-size-prefix);
 			}
 		}
 		/* 	2/12 */
-		.c1-2,.c2-3,.c3-4,.c4-5,.c5-6,.c6-7,.c7-8,.c8-9,.c9-10,.c10-11,.c11-12 { @include cg-width(map-get($_map, column-width), map-get($_map, col-margins), 2); }
+		.c1-2,.c2-3,.c3-4,.c4-5,.c5-6,.c6-7,.c7-8,.c8-9,.c9-10,.c10-11,.c11-12 { @include cg-cols-width(map-get($_map, column-width), map-get($_map, col-margins), 2); }
 		.offset2 { @include cg-offset(map-get($_map, column-width), map-get($_map, col-margins), 2); }
 		/* 	3/12 */
-		.c1-3,.c2-4,.c3-5,.c4-6,.c5-7,.c6-8,.c7-9,.c8-10,.c9-11,.c10-12 { @include cg-width(map-get($_map, column-width), map-get($_map, col-margins), 3); }
+		.c1-3,.c2-4,.c3-5,.c4-6,.c5-7,.c6-8,.c7-9,.c8-10,.c9-11,.c10-12 { @include cg-cols-width(map-get($_map, column-width), map-get($_map, col-margins), 3); }
 		.offset3 { @include cg-offset(map-get($_map, column-width), map-get($_map, col-margins), 3); }
 		/* 	4/12 */
-		.c1-4,.c2-5,.c3-6,.c4-7,.c5-8,.c6-9,.c7-10,.c8-11,.c9-12 { @include cg-width(map-get($_map, column-width), map-get($_map, col-margins), 4); }
+		.c1-4,.c2-5,.c3-6,.c4-7,.c5-8,.c6-9,.c7-10,.c8-11,.c9-12 { @include cg-cols-width(map-get($_map, column-width), map-get($_map, col-margins), 4); }
 		.offset4 { @include cg-offset(map-get($_map, column-width), map-get($_map, col-margins), 4); }
 		/* 	5/12 */
-		.c1-5,.c2-6,.c3-7,.c4-8,.c5-9,.c6-10,.c7-11,.c8-12 { @include cg-width(map-get($_map, column-width), map-get($_map, col-margins), 5); }
+		.c1-5,.c2-6,.c3-7,.c4-8,.c5-9,.c6-10,.c7-11,.c8-12 { @include cg-cols-width(map-get($_map, column-width), map-get($_map, col-margins), 5); }
 		.offset5 { @include cg-offset(map-get($_map, column-width), map-get($_map, col-margins), 5); }
 		/* 	6/12 */
-		.c1-6,.c2-7,.c3-8,.c4-9,.c5-10,.c6-11,.c7-12 { @include cg-width(map-get($_map, column-width), map-get($_map, col-margins), 6); }
+		.c1-6,.c2-7,.c3-8,.c4-9,.c5-10,.c6-11,.c7-12 { @include cg-cols-width(map-get($_map, column-width), map-get($_map, col-margins), 6); }
 		.offset6 { @include cg-offset(map-get($_map, column-width), map-get($_map, col-margins), 6); }
 		/* 	7/12 */
-		.c1-7,.c2-8,.c3-9,.c4-10,.c5-11,.c6-12 { @include cg-width(map-get($_map, column-width), map-get($_map, col-margins), 7); }
+		.c1-7,.c2-8,.c3-9,.c4-10,.c5-11,.c6-12 { @include cg-cols-width(map-get($_map, column-width), map-get($_map, col-margins), 7); }
 		.offset7 { @include cg-offset(map-get($_map, column-width), map-get($_map, col-margins), 7); }
 		/* 	8/12 */
-		.c1-8,.c2-9,.c3-10,.c4-11,.c5-12 { @include cg-width(map-get($_map, column-width), map-get($_map, col-margins), 8); }
+		.c1-8,.c2-9,.c3-10,.c4-11,.c5-12 { @include cg-cols-width(map-get($_map, column-width), map-get($_map, col-margins), 8); }
 		.offset8 { @include cg-offset(map-get($_map, column-width), map-get($_map, col-margins), 8); }
 		/* 	9/12 */
-		.c1-9,.c2-10,.c3-11,.c4-12 { @include cg-width(map-get($_map, column-width), map-get($_map, col-margins), 9); }
+		.c1-9,.c2-10,.c3-11,.c4-12 { @include cg-cols-width(map-get($_map, column-width), map-get($_map, col-margins), 9); }
 		.offset9 { @include cg-offset(map-get($_map, column-width), map-get($_map, col-margins), 9); }
 		/* 	10/12 */
-		.c1-10,.c2-11,.c3-12 { @include cg-width(map-get($_map, column-width), map-get($_map, col-margins), 10); }
+		.c1-10,.c2-11,.c3-12 { @include cg-cols-width(map-get($_map, column-width), map-get($_map, col-margins), 10); }
 		.offset10 { @include cg-offset(map-get($_map, column-width), map-get($_map, col-margins), 10); }
 		/* 	11/12 */
-		.c1-11,.c2-12 { @include cg-width(map-get($_map, column-width), map-get($_map, col-margins), 11); }
+		.c1-11,.c2-12 { @include cg-cols-width(map-get($_map, column-width), map-get($_map, col-margins), 11); }
 		.offset11 { @include cg-offset(map-get($_map, column-width), map-get($_map, col-margins), 11); }
 		/* 	12/12 */
-		.c1-12 { @include cg-width(map-get($_map, column-width), map-get($_map, col-margins), 12); }
+		.c1-12 { @include cg-cols-width(map-get($_map, column-width), map-get($_map, col-margins), 12); }
 
 		/* 	Accounts for extra margin on first column
 			This value should change a negative margin of whatever your gutter width is. */

--- a/sass/grid.scss
+++ b/sass/grid.scss
@@ -24,7 +24,7 @@ $cg-md-col-margins: 20px !default;
 
 // Small (mobile) in px
 $cg-sm-grid-inner-width: 760px !default;
-$cg-sm-grid-gutter: 20px !default;
+$cg-sm-grid-gutter: 0px !default;
 $cg-sm-col-margins: 20px !default;
 
 // Smallest (block) in px
@@ -120,6 +120,15 @@ $_cg-default-size-map: map-get($_cg-size-map, $cg-default-size-prefix);
 
 /** mixins
  -------------------------------------------------- */
+
+/**
+ * Prints a width definition to be used by .grid.
+ */
+@mixin cg-grid-width-for-size($size-prefix) {
+	$_map: map-get($_cg-size-map, $size-prefix);
+	$_width: if($cg-use-border-box, map-get($_map, grid-total-width), map-get($_map, grid-inner-width));
+}
+
 @mixin cg-gutters($gutter) {
 	padding-left: $gutter;
 	padding-right: $gutter;
@@ -183,12 +192,7 @@ $_cg-default-size-map: map-get($_cg-size-map, $cg-default-size-prefix);
 		// --- The rest of the sizes use the routine below.
 		.grid {
 			@include cg-gutters(map-get($_map, grid-gutter));
-			// width: map-get($_map, grid-inner-width);
-			@if $cg-use-border-box {
-				width: map-get($_map, grid-inner-width) + (map-get($_map, grid-gutter) * 2);
-			} @else {
-				width: map-get($_map, grid-inner-width);
-			}
+			@include cg-grid-width-for-size($size-prefix);
 		}
 		.c1,.c2,.c3,.c4,.c5,.c6,.c7,.c8,.c9,.c10,.c11,.c12,
 		.c1-2,.c2-3,.c3-4,.c4-5,.c5-6,.c6-7,.c7-8,.c8-9,.c9-10,.c10-11,.c11-12,

--- a/sass/grid.scss
+++ b/sass/grid.scss
@@ -8,76 +8,93 @@
  To provide your own values for the variables below, simply re-define them in your Sass prior
  to importing this partial. You can only customize variables that include the !default flag.
  -------------------------------------------------- */
-$use-lg-breakpoint: false !default;
+$cg-use-lg-breakpoint: false !default;
+$cg-default-size-prefix: 'sm' !default; // formerly md
 
 // Large (large desktop) in px
-$lg-grid-inner-width: 1420px !default;
-$lg-grid-gutter: 0px !default;
-$lg-col-margins: 20px !default;
+$cg-lg-grid-inner-width: 1420px !default;
+$cg-lg-grid-gutter: 0px !default;
+$cg-lg-col-margins: 20px !default;
 
 // Medium (tablet/desktop) in px
-$md-grid-inner-width: 1048px !default;
-$md-grid-gutter: 0px !default;
-$md-col-margins: 20px !default;
+$cg-md-grid-inner-width: 1048px !default;
+$cg-md-grid-gutter: 0px !default;
+$cg-md-col-margins: 20px !default;
 
 // Small (mobile) in px
-$sm-grid-inner-width: 760px !default;
-$sm-grid-gutter: 20px !default;
-$sm-col-margins: 20px !default;
+$cg-sm-grid-inner-width: 760px !default;
+$cg-sm-grid-gutter: 20px !default;
+$cg-sm-col-margins: 20px !default;
 
 // Smallest (block) in px
-$xs-grid-gutter: 10px !default;
+$cg-xs-grid-gutter: 10px !default;
 
 // Grid total widths (not overridable)
-$lg-grid-total-width: $lg-grid-inner-width + (2 * $lg-grid-gutter);
-$md-grid-total-width: $md-grid-inner-width + (2 * $md-grid-gutter);
-$sm-grid-total-width: $sm-grid-inner-width + (2 * $sm-grid-gutter);
+$cg-lg-grid-total-width: $cg-lg-grid-inner-width + (2 * $cg-lg-grid-gutter);
+$cg-md-grid-total-width: $cg-md-grid-inner-width + (2 * $cg-md-grid-gutter);
+$cg-sm-grid-total-width: $cg-sm-grid-inner-width + (2 * $cg-sm-grid-gutter);
 
 // Break Points
-$lg-bp-min-width: $lg-grid-total-width;
-$md-bp-max-width: $lg-grid-total-width - 1 !default;
-$md-bp-min-width: $md-grid-total-width !default;
-$sm-bp-max-width: $md-grid-total-width - 1 !default;
-$sm-bp-min-width: $sm-grid-total-width !default;
-$xs-bp-max-width: $sm-grid-total-width - 1 !default;
+$cg-lg-bp-min-width: $cg-lg-grid-total-width;
+$cg-md-bp-max-width: $cg-lg-grid-total-width - 1 !default;
+$cg-md-bp-min-width: $cg-md-grid-total-width !default;
+$cg-sm-bp-max-width: $cg-md-grid-total-width - 1 !default;
+$cg-sm-bp-min-width: $cg-sm-grid-total-width !default;
+$cg-xs-bp-max-width: $cg-sm-grid-total-width - 1 !default;
 
 // Media queries
-$lg-mq: '(min-width: #{$lg-bp-min-width})' !default; // formerly "desktop-mq"
-$md-mq: if($use-lg-breakpoint, '(min-width: #{$md-bp-min-width}) and (max-width: #{$md-bp-max-width})', '(min-width: #{$md-bp-min-width})') !default; // formerly "tablet-mq"
-$sm-mq: '(min-width: #{$sm-bp-min-width}) and (max-width: #{$sm-bp-max-width})' !default; // formerly "phone-mq"
-$xs-mq: '(max-width: #{$xs-bp-max-width})' !default;
+$cg-lg-mq: '(min-width: #{$cg-lg-bp-min-width})' !default; // formerly "desktop-mq"
+$cg-md-mq: if($cg-use-lg-breakpoint, '(min-width: #{$cg-md-bp-min-width}) and (max-width: #{$cg-md-bp-max-width})', '(min-width: #{$cg-md-bp-min-width})') !default; // formerly "tablet-mq"
+$cg-sm-mq: '(min-width: #{$cg-sm-bp-min-width}) and (max-width: #{$cg-sm-bp-max-width})' !default; // formerly "phone-mq"
+$cg-xs-mq: '(max-width: #{$cg-xs-bp-max-width})' !default;
 
 // Column count (not overridable)
-$column-count: 12;
+$cg-column-count: 12;
 
 // Column widths (not overridable)
-$lg-column-width: (($lg-grid-inner-width - (($lg-col-margins * ($column-count - 1)))) / $column-count);
-$md-column-width: (($md-grid-inner-width - (($md-col-margins * ($column-count - 1)))) / $column-count);
-$sm-column-width: (($sm-grid-inner-width - (($sm-col-margins * ($column-count - 1)))) / $column-count);
+$cg-lg-column-width: (($cg-lg-grid-inner-width - (($cg-lg-col-margins * ($cg-column-count - 1)))) / $cg-column-count);
+$cg-md-column-width: (($cg-md-grid-inner-width - (($cg-md-col-margins * ($cg-column-count - 1)))) / $cg-column-count);
+$cg-sm-column-width: (($cg-sm-grid-inner-width - (($cg-sm-col-margins * ($cg-column-count - 1)))) / $cg-column-count);
 
-/** mixins
+/** move vars to a map for dynamic usage
  -------------------------------------------------- */
-@mixin gutters($gutter) {
-	padding-left: $gutter;
-	padding-right: $gutter;
-}
+$_cg-size-map: (
+	xs: (
+		grid-gutter: $cg-xs-grid-gutter,
+		mq: $cg-xs-mq
+	),
+	sm: (
+		grid-inner-width: $cg-sm-grid-inner-width,
+		grid-gutter: $cg-sm-grid-gutter,
+		col-margins: $cg-sm-col-margins,
+		grid-total-width: $cg-sm-grid-total-width,
+		bp-max-width: $cg-sm-bp-max-width,
+		bp-min-width: $cg-sm-bp-min-width,
+		column-width: $cg-sm-column-width,
+		mq: $cg-sm-mq
+	),
+	md: (
+		grid-inner-width: $cg-md-grid-inner-width,
+		grid-gutter: $cg-md-grid-gutter,
+		col-margins: $cg-md-col-margins,
+		grid-total-width: $cg-md-grid-total-width,
+		bp-max-width: $cg-md-bp-max-width,
+		bp-min-width: $cg-md-bp-min-width,
+		column-width: $cg-md-column-width,
+		mq: $cg-md-mq
+	),
+	lg: (
+		grid-inner-width: $cg-lg-grid-inner-width,
+		grid-gutter: $cg-lg-grid-gutter,
+		col-margins: $cg-lg-col-margins,
+		grid-total-width: $cg-lg-grid-total-width,
+		bp-min-width: $cg-lg-bp-min-width,
+		column-width: $cg-lg-column-width,
+		mq: $cg-lg-mq
+	)
+);
 
-@mixin width($col-width, $margin-width, $multiplier: 1) {
-	width: (($col-width * $multiplier) + (($multiplier - 1) * $margin-width));
-}
-
-@mixin offset($col-width, $margin-width, $multiplier: 1, $first: false) {
-	@if $first {
-		margin-left: (($col-width * $multiplier) + ($multiplier * $margin-width));
-	}
-	@else {
-		margin-left: (($col-width * $multiplier) + ($multiplier * $margin-width) + $margin-width);
-	}
-}
-
-@mixin row($margin) {
-	margin-left: -$margin;
-}
+$_cg-default-size-map: map-get($_cg-size-map, $cg-default-size-prefix);
 
 /** grid foundation
  -------------------------------------------------- */
@@ -93,185 +110,72 @@ $sm-column-width: (($sm-grid-inner-width - (($sm-col-margins * ($column-count - 
 	max-width: 100%;
 }
 
-/* 	Default Desktop/Tablet Grid
-	Works fine with older browsers that don't support media queries. */
-.grid {
-	/* this makes the page wide but keeps content away from the edge */
-	@include gutters($md-grid-gutter);
-	width: $md-grid-inner-width;
-}
-.c1,.c2,.c3,.c4,.c5,.c6,.c7,.c8,.c9,.c10,.c11,.c12,
-.c1-2,.c2-3,.c3-4,.c4-5,.c5-6,.c6-7,.c7-8,.c8-9,.c9-10,.c10-11,.c11-12,
-.c1-3,.c2-4,.c3-5,.c4-6,.c5-7,.c6-8,.c7-9,.c8-10,.c9-11,.c10-12,
-.c1-4,.c2-5,.c3-6,.c4-7,.c5-8,.c6-9,.c7-10,.c8-11,.c9-12,
-.c1-5,.c2-6,.c3-7,.c4-8,.c5-9,.c6-10,.c7-11,.c8-12,
-.c1-6,.c2-7,.c3-8,.c4-9,.c5-10,.c6-11,.c7-12,
-.c1-7,.c2-8,.c3-9,.c4-10,.c5-11,.c6-12,
-.c1-8,.c2-9,.c3-10,.c4-11,.c5-12,
-.c1-9,.c2-10,.c3-11,.c4-12,
-.c1-10,.c2-11,.c3-12,
-.c1-11,.c2-12,
-.c1-12	{
-	margin-left: $md-col-margins;
-	display: inline;
-	float: left;
-	min-height: 1px;
+/** mixins
+ -------------------------------------------------- */
+@mixin cg-gutters($gutter) {
+	padding-left: $gutter;
+	padding-right: $gutter;
 }
 
-/* 	1/12 */
-	.c1,.c2,.c3,.c4,.c5,.c6,.c7,.c8,.c9,.c10,.c11,.c12 { @include width($md-column-width, $md-col-margins); }
-	.offset1 { @include offset($md-column-width, $md-col-margins); }
-	[class*=c1-],
-	[class*=c2-],
-	[class*=c3-],
-	[class*=c4-],
-	[class*=c5-],
-	[class*=c6-],
-	[class*=c7-],
-	[class*=c8-],
-	[class*=c9-],
-	[class*=c10-],
-	[class*=c11-],
-	[class*=c12-] {
-		.offset1:first-child {
-			@include offset($md-column-width, $md-col-margins, 1, true);
-		}
-	}
-/* 	2/12 */
-	.c1-2,.c2-3,.c3-4,.c4-5,.c5-6,.c6-7,.c7-8,.c8-9,.c9-10,.c10-11,.c11-12 { @include width($md-column-width, $md-col-margins, 2); }
-	.offset2 { @include offset($md-column-width, $md-col-margins, 2); }
-/* 	3/12 */
-	.c1-3,.c2-4,.c3-5,.c4-6,.c5-7,.c6-8,.c7-9,.c8-10,.c9-11,.c10-12 { @include width($md-column-width, $md-col-margins, 3); }
-	.offset3 { @include offset($md-column-width, $md-col-margins, 3); }
-/* 	4/12 */
-	.c1-4,.c2-5,.c3-6,.c4-7,.c5-8,.c6-9,.c7-10,.c8-11,.c9-12 { @include width($md-column-width, $md-col-margins, 4); }
-	.offset4 { @include offset($md-column-width, $md-col-margins, 4); }
-/* 	5/12 */
-	.c1-5,.c2-6,.c3-7,.c4-8,.c5-9,.c6-10,.c7-11,.c8-12 { @include width($md-column-width, $md-col-margins, 5); }
-	.offset5 { @include offset($md-column-width, $md-col-margins, 5); }
-/* 	6/12 */
-	.c1-6,.c2-7,.c3-8,.c4-9,.c5-10,.c6-11,.c7-12 { @include width($md-column-width, $md-col-margins, 6); }
-	.offset6 { @include offset($md-column-width, $md-col-margins, 6); }
-/* 	7/12 */
-	.c1-7,.c2-8,.c3-9,.c4-10,.c5-11,.c6-12 { @include width($md-column-width, $md-col-margins, 7); }
-	.offset7 { @include offset($md-column-width, $md-col-margins, 7); }
-/* 	8/12 */
-	.c1-8,.c2-9,.c3-10,.c4-11,.c5-12 { @include width($md-column-width, $md-col-margins, 8); }
-	.offset8 { @include offset($md-column-width, $md-col-margins, 8); }
-/* 	9/12 */
-	.c1-9,.c2-10,.c3-11,.c4-12 { @include width($md-column-width, $md-col-margins, 9); }
-	.offset9 { @include offset($md-column-width, $md-col-margins, 9); }
-/* 	10/12 */
-	.c1-10,.c2-11,.c3-12 { @include width($md-column-width, $md-col-margins, 10); }
-	.offset10 { @include offset($md-column-width, $md-col-margins, 10); }
-/* 	11/12 */
-	.c1-11,.c2-12 { @include width($md-column-width, $md-col-margins, 11); }
-	.offset11 { @include offset($md-column-width, $md-col-margins, 11); }
-/* 	12/12 */
-	.c1-12 { @include width($md-column-width, $md-col-margins, 12); }
-/* 	Accounts for extra margin on first column
-		This value should change a negative margin of whatever your gutter width is. */
-	.row {
-		@include row($md-col-margins);
-	}
+@mixin cg-width($col-width, $margin-width, $multiplier: 1) {
+	width: (($col-width * $multiplier) + (($multiplier - 1) * $margin-width));
+}
 
-
-/* 	Small Sized Grid
-	Tablet sized columns. */
-@media only screen and #{$sm-mq} {
-	.grid {
-		@include gutters($sm-grid-gutter);
-		width: $sm-grid-inner-width;
+@mixin cg-offset($col-width, $margin-width, $multiplier: 1, $first: false) {
+	@if $first {
+		margin-left: (($col-width * $multiplier) + ($multiplier * $margin-width));
 	}
-	.c1,.c2,.c3,.c4,.c5,.c6,.c7,.c8,.c9,.c10,.c11,.c12,
-	.c1-2,.c2-3,.c3-4,.c4-5,.c5-6,.c6-7,.c7-8,.c8-9,.c9-10,.c10-11,.c11-12,
-	.c1-3,.c2-4,.c3-5,.c4-6,.c5-7,.c6-8,.c7-9,.c8-10,.c9-11,.c10-12,
-	.c1-4,.c2-5,.c3-6,.c4-7,.c5-8,.c6-9,.c7-10,.c8-11,.c9-12,
-	.c1-5,.c2-6,.c3-7,.c4-8,.c5-9,.c6-10,.c7-11,.c8-12,
-	.c1-6,.c2-7,.c3-8,.c4-9,.c5-10,.c6-11,.c7-12,
-	.c1-7,.c2-8,.c3-9,.c4-10,.c5-11,.c6-12,
-	.c1-8,.c2-9,.c3-10,.c4-11,.c5-12,
-	.c1-9,.c2-10,.c3-11,.c4-12,
-	.c1-10,.c2-11,.c3-12,
-	.c1-11,.c2-12,
-	.c1-12	{
-		display: inline; /* IE6/IE7 double-margin float bug fix */
-		float: left;
-		margin-left: $sm-col-margins;
-		/* Prevent collapsing of empty columns. Min-height prevents collapse
-		everywhere but IE6. IE6 doesn't collapse empty collumns anyhow, so no need
-		for a fix there. */
-		min-height: 1px;
-		clear: none;
-	}
-/* 	1/12 */
-	.c1,.c2,.c3,.c4,.c5,.c6,.c7,.c8,.c9,.c10,.c11,.c12 { @include width($sm-column-width, $sm-col-margins); }
-	.offset1 { @include offset($sm-column-width, $sm-col-margins); }
-	[class*=c1-],
-	[class*=c2-],
-	[class*=c3-],
-	[class*=c4-],
-	[class*=c5-],
-	[class*=c6-],
-	[class*=c7-],
-	[class*=c8-],
-	[class*=c9-],
-	[class*=c10-],
-	[class*=c11-],
-	[class*=c12-] {
-		.offset1:first-child {
-			@include offset($sm-column-width, $sm-col-margins, 1, true);
-		}
-	}
-/* 	2/12 */
-	.c1-2,.c2-3,.c3-4,.c4-5,.c5-6,.c6-7,.c7-8,.c8-9,.c9-10,.c10-11,.c11-12 { @include width($sm-column-width, $sm-col-margins, 2); }
-	.offset2 { @include offset($sm-column-width, $sm-col-margins, 2); }
-/* 	3/12 */
-	.c1-3,.c2-4,.c3-5,.c4-6,.c5-7,.c6-8,.c7-9,.c8-10,.c9-11,.c10-12 { @include width($sm-column-width, $sm-col-margins, 3); }
-	.offset3 { @include offset($sm-column-width, $sm-col-margins, 3); }
-/* 	4/12 */
-	.c1-4,.c2-5,.c3-6,.c4-7,.c5-8,.c6-9,.c7-10,.c8-11,.c9-12 { @include width($sm-column-width, $sm-col-margins, 4); }
-	.offset4 { @include offset($sm-column-width, $sm-col-margins, 4); }
-/* 	5/12 */
-	.c1-5,.c2-6,.c3-7,.c4-8,.c5-9,.c6-10,.c7-11,.c8-12 { @include width($sm-column-width, $sm-col-margins, 5); }
-	.offset5 { @include offset($sm-column-width, $sm-col-margins, 5); }
-/* 	6/12 */
-	.c1-6,.c2-7,.c3-8,.c4-9,.c5-10,.c6-11,.c7-12 { @include width($sm-column-width, $sm-col-margins, 6); }
-	.offset6 { @include offset($sm-column-width, $sm-col-margins, 6); }
-/* 	7/12 */
-	.c1-7,.c2-8,.c3-9,.c4-10,.c5-11,.c6-12 { @include width($sm-column-width, $sm-col-margins, 7); }
-	.offset7 { @include offset($sm-column-width, $sm-col-margins, 7); }
-/* 	8/12 */
-	.c1-8,.c2-9,.c3-10,.c4-11,.c5-12 { @include width($sm-column-width, $sm-col-margins, 8); }
-	.offset8 { @include offset($sm-column-width, $sm-col-margins, 8); }
-/* 	9/12 */
-	.c1-9,.c2-10,.c3-11,.c4-12 { @include width($sm-column-width, $sm-col-margins, 9); }
-	.offset9 { @include offset($sm-column-width, $sm-col-margins, 9); }
-/* 	10/12 */
-	.c1-10,.c2-11,.c3-12 { @include width($sm-column-width, $sm-col-margins, 10); }
-	.offset10 { @include offset($sm-column-width, $sm-col-margins, 10); }
-/* 	11/12 */
-	.c1-11,.c2-12 { @include width($sm-column-width, $sm-col-margins, 11); }
-	.offset11 { @include offset($sm-column-width, $sm-col-margins, 11); }
-/* 	12/12 */
-	.c1-12 { @include width($sm-column-width, $sm-col-margins, 12); }
-
-/* 	Accounts for extra margin on first column
-	This value should change a negative margin of whatever your gutter width is. */
-	.row {
-		@include row($sm-col-margins);
+	@else {
+		margin-left: (($col-width * $multiplier) + ($multiplier * $margin-width) + $margin-width);
 	}
 }
 
+@mixin cg-row($margin) {
+	margin-left: -$margin;
+}
 
-/* 	Large Desktop Grid
-	Very wide columns for large monitors. */
+/**
+ * Generates the grid CSS for a given size prefix.
+ *
+ * This should be called within the media query associated with the size prefix.
+ */
+@mixin _cg-generate-for-size($size-prefix) {
+	$_map: map-get($_cg-size-map, $size-prefix);
 
-@if $use-lg-breakpoint {
-	@media only screen and #{$lg-mq} {
+	@if($size-prefix == 'xs') {
+		// --- The "xs" size is special and has unique output.
 		.grid {
-			@include gutters($lg-grid-gutter);
-			width: $lg-grid-inner-width;
+			@include cg-gutters(map-get($_map, grid-gutter));
+			width: auto;
+		}
+		.grid,
+		.c1,.c2,.c3,.c4,.c5,.c6,.c7,.c8,.c9,.c10,.c11,.c12,
+		.c1-2,.c2-3,.c3-4,.c4-5,.c5-6,.c6-7,.c7-8,.c8-9,.c9-10,.c10-11,.c11-12,
+		.c1-3,.c2-4,.c3-5,.c4-6,.c5-7,.c6-8,.c7-9,.c8-10,.c9-11,.c10-12,
+		.c1-4,.c2-5,.c3-6,.c4-7,.c5-8,.c6-9,.c7-10,.c8-11,.c9-12,
+		.c1-5,.c2-6,.c3-7,.c4-8,.c5-9,.c6-10,.c7-11,.c8-12,
+		.c1-6,.c2-7,.c3-8,.c4-9,.c5-10,.c6-11,.c7-12,
+		.c1-7,.c2-8,.c3-9,.c4-10,.c5-11,.c6-12,
+		.c1-8,.c2-9,.c3-10,.c4-11,.c5-12,
+		.c1-9,.c2-10,.c3-11,.c4-12,
+		.c1-10,.c2-11,.c3-12,
+		.c1-11,.c2-12,
+		.c1-12	{
+			display: block;
+			float: none;
+			margin-left: 0;
+			width: auto;
+		}
+		.row {
+			margin-left: 0;
+		}
+		// --- (end 'xs' generation)
+
+	} @else {
+		// --- The rest of the sizes use the routine below.
+		.grid {
+			@include cg-gutters(map-get($_map, grid-gutter));
+			width: map-get($_map, grid-inner-width);
 		}
 		.c1,.c2,.c3,.c4,.c5,.c6,.c7,.c8,.c9,.c10,.c11,.c12,
 		.c1-2,.c2-3,.c3-4,.c4-5,.c5-6,.c6-7,.c7-8,.c8-9,.c9-10,.c10-11,.c11-12,
@@ -285,15 +189,18 @@ $sm-column-width: (($sm-grid-inner-width - (($sm-col-margins * ($column-count - 
 		.c1-10,.c2-11,.c3-12,
 		.c1-11,.c2-12,
 		.c1-12	{
-			margin-left: $lg-col-margins;
-			display: inline;
+			display: inline; /* IE6/IE7 double-margin float bug fix */
 			float: left;
+			margin-left: map-get($_map, col-margins);
+			/* Prevent collapsing of empty columns. Min-height prevents collapse
+			everywhere but IE6. IE6 doesn't collapse empty collumns anyhow, so no need
+			for a fix there. */
 			min-height: 1px;
+			clear: none;
 		}
-
-	/* 	1/12 */
-		.c1,.c2,.c3,.c4,.c5,.c6,.c7,.c8,.c9,.c10,.c11,.c12 { @include width($lg-column-width, $lg-col-margins); }
-		.offset1 { @include offset($lg-column-width, $lg-col-margins); }
+		/* 	1/12 */
+		.c1,.c2,.c3,.c4,.c5,.c6,.c7,.c8,.c9,.c10,.c11,.c12 { @include cg-width(map-get($_map, column-width), map-get($_map, col-margins)); }
+		.offset1 { @include cg-offset(map-get($_map, column-width), map-get($_map, col-margins)); }
 		[class*=c1-],
 		[class*=c2-],
 		[class*=c3-],
@@ -307,78 +214,92 @@ $sm-column-width: (($sm-grid-inner-width - (($sm-col-margins * ($column-count - 
 		[class*=c11-],
 		[class*=c12-] {
 			.offset1:first-child {
-				@include offset($lg-column-width, $lg-col-margins, 1, true);
+				@include cg-offset(map-get($_map, column-width), map-get($_map, col-margins), 1, true);
 			}
 		}
-	/* 	2/12 */
-		.c1-2,.c2-3,.c3-4,.c4-5,.c5-6,.c6-7,.c7-8,.c8-9,.c9-10,.c10-11,.c11-12 { @include width($lg-column-width, $lg-col-margins, 2); }
-		.offset2 { @include offset($lg-column-width, $lg-col-margins, 2); }
-	/* 	3/12 */
-		.c1-3,.c2-4,.c3-5,.c4-6,.c5-7,.c6-8,.c7-9,.c8-10,.c9-11,.c10-12 { @include width($lg-column-width, $lg-col-margins, 3); }
-		.offset3 { @include offset($lg-column-width, $lg-col-margins, 3); }
-	/* 	4/12 */
-		.c1-4,.c2-5,.c3-6,.c4-7,.c5-8,.c6-9,.c7-10,.c8-11,.c9-12 { @include width($lg-column-width, $lg-col-margins, 4); }
-		.offset4 { @include offset($lg-column-width, $lg-col-margins, 4); }
-	/* 	5/12 */
-		.c1-5,.c2-6,.c3-7,.c4-8,.c5-9,.c6-10,.c7-11,.c8-12 { @include width($lg-column-width, $lg-col-margins, 5); }
-		.offset5 { @include offset($lg-column-width, $lg-col-margins, 5); }
-	/* 	6/12 */
-		.c1-6,.c2-7,.c3-8,.c4-9,.c5-10,.c6-11,.c7-12 { @include width($lg-column-width, $lg-col-margins, 6); }
-		.offset6 { @include offset($lg-column-width, $lg-col-margins, 6); }
-	/* 	7/12 */
-		.c1-7,.c2-8,.c3-9,.c4-10,.c5-11,.c6-12 { @include width($lg-column-width, $lg-col-margins, 7); }
-		.offset7 { @include offset($lg-column-width, $lg-col-margins, 7); }
-	/* 	8/12 */
-		.c1-8,.c2-9,.c3-10,.c4-11,.c5-12 { @include width($lg-column-width, $lg-col-margins, 8); }
-		.offset8 { @include offset($lg-column-width, $lg-col-margins, 8); }
-	/* 	9/12 */
-		.c1-9,.c2-10,.c3-11,.c4-12 { @include width($lg-column-width, $lg-col-margins, 9); }
-		.offset9 { @include offset($lg-column-width, $lg-col-margins, 9); }
-	/* 	10/12 */
-		.c1-10,.c2-11,.c3-12 { @include width($lg-column-width, $lg-col-margins, 10); }
-		.offset10 { @include offset($lg-column-width, $lg-col-margins, 10); }
-	/* 	11/12 */
-		.c1-11,.c2-12 { @include width($lg-column-width, $lg-col-margins, 11); }
-		.offset11 { @include offset($lg-column-width, $lg-col-margins, 11); }
-	/* 	12/12 */
-		.c1-12 { @include width($lg-column-width, $lg-col-margins, 12); }
+		/* 	2/12 */
+		.c1-2,.c2-3,.c3-4,.c4-5,.c5-6,.c6-7,.c7-8,.c8-9,.c9-10,.c10-11,.c11-12 { @include cg-width(map-get($_map, column-width), map-get($_map, col-margins), 2); }
+		.offset2 { @include cg-offset(map-get($_map, column-width), map-get($_map, col-margins), 2); }
+		/* 	3/12 */
+		.c1-3,.c2-4,.c3-5,.c4-6,.c5-7,.c6-8,.c7-9,.c8-10,.c9-11,.c10-12 { @include cg-width(map-get($_map, column-width), map-get($_map, col-margins), 3); }
+		.offset3 { @include cg-offset(map-get($_map, column-width), map-get($_map, col-margins), 3); }
+		/* 	4/12 */
+		.c1-4,.c2-5,.c3-6,.c4-7,.c5-8,.c6-9,.c7-10,.c8-11,.c9-12 { @include cg-width(map-get($_map, column-width), map-get($_map, col-margins), 4); }
+		.offset4 { @include cg-offset(map-get($_map, column-width), map-get($_map, col-margins), 4); }
+		/* 	5/12 */
+		.c1-5,.c2-6,.c3-7,.c4-8,.c5-9,.c6-10,.c7-11,.c8-12 { @include cg-width(map-get($_map, column-width), map-get($_map, col-margins), 5); }
+		.offset5 { @include cg-offset(map-get($_map, column-width), map-get($_map, col-margins), 5); }
+		/* 	6/12 */
+		.c1-6,.c2-7,.c3-8,.c4-9,.c5-10,.c6-11,.c7-12 { @include cg-width(map-get($_map, column-width), map-get($_map, col-margins), 6); }
+		.offset6 { @include cg-offset(map-get($_map, column-width), map-get($_map, col-margins), 6); }
+		/* 	7/12 */
+		.c1-7,.c2-8,.c3-9,.c4-10,.c5-11,.c6-12 { @include cg-width(map-get($_map, column-width), map-get($_map, col-margins), 7); }
+		.offset7 { @include cg-offset(map-get($_map, column-width), map-get($_map, col-margins), 7); }
+		/* 	8/12 */
+		.c1-8,.c2-9,.c3-10,.c4-11,.c5-12 { @include cg-width(map-get($_map, column-width), map-get($_map, col-margins), 8); }
+		.offset8 { @include cg-offset(map-get($_map, column-width), map-get($_map, col-margins), 8); }
+		/* 	9/12 */
+		.c1-9,.c2-10,.c3-11,.c4-12 { @include cg-width(map-get($_map, column-width), map-get($_map, col-margins), 9); }
+		.offset9 { @include cg-offset(map-get($_map, column-width), map-get($_map, col-margins), 9); }
+		/* 	10/12 */
+		.c1-10,.c2-11,.c3-12 { @include cg-width(map-get($_map, column-width), map-get($_map, col-margins), 10); }
+		.offset10 { @include cg-offset(map-get($_map, column-width), map-get($_map, col-margins), 10); }
+		/* 	11/12 */
+		.c1-11,.c2-12 { @include cg-width(map-get($_map, column-width), map-get($_map, col-margins), 11); }
+		.offset11 { @include cg-offset(map-get($_map, column-width), map-get($_map, col-margins), 11); }
+		/* 	12/12 */
+		.c1-12 { @include cg-width(map-get($_map, column-width), map-get($_map, col-margins), 12); }
 
 		/* 	Accounts for extra margin on first column
 			This value should change a negative margin of whatever your gutter width is. */
 		.row {
-			@include row($lg-col-margins);
+			@include cg-row(map-get($_map, col-margins));
+		}
+		// --- (end non-'xs' code generation)
+	}
+} // ends _cg-generate-for-size()
+
+
+/* 	Default Grid
+	Uses $cg-default-size-prefix and sets the defaults for browsers that don't support media queries. */
+@include _cg-generate-for-size($cg-default-size-prefix);
+
+
+/* 	Small Sized Grid
+	Tablet sized columns. */
+@media only screen and #{$cg-sm-mq} {
+	// Only need generate this output if small wasn't the default.
+	@if $cg-default-size-prefix != 'sm' {
+		@include _cg-generate-for-size('sm');
+	}
+}
+
+/* 	Medium Sized Grid
+	Desktop sized columns. */
+@media only screen and #{$cg-md-mq} {
+	// Only need generate this output if medium wasn't the default.
+	@if $cg-default-size-prefix != 'md' {
+		@include _cg-generate-for-size('md');
+	}
+}
+
+/* 	Large Desktop Grid
+	Very wide columns for large monitors. */
+@if $cg-use-lg-breakpoint {
+	@media only screen and #{$cg-lg-mq} {
+		// Only need generate this output if large wasn't the default.
+		@if $cg-default-size-prefix != 'lg' {
+			@include _cg-generate-for-size('lg');
 		}
 	}
 }
 
 /* 	Single-column mobile
 	Get rid of widths and floats, go to fluid single column. */
-@media only screen and #{$xs-mq} {
-	.grid {
-		@include gutters($xs-grid-gutter);
-		width: auto;
-	}
-
-	.grid,
-	.c1,.c2,.c3,.c4,.c5,.c6,.c7,.c8,.c9,.c10,.c11,.c12,
-	.c1-2,.c2-3,.c3-4,.c4-5,.c5-6,.c6-7,.c7-8,.c8-9,.c9-10,.c10-11,.c11-12,
-	.c1-3,.c2-4,.c3-5,.c4-6,.c5-7,.c6-8,.c7-9,.c8-10,.c9-11,.c10-12,
-	.c1-4,.c2-5,.c3-6,.c4-7,.c5-8,.c6-9,.c7-10,.c8-11,.c9-12,
-	.c1-5,.c2-6,.c3-7,.c4-8,.c5-9,.c6-10,.c7-11,.c8-12,
-	.c1-6,.c2-7,.c3-8,.c4-9,.c5-10,.c6-11,.c7-12,
-	.c1-7,.c2-8,.c3-9,.c4-10,.c5-11,.c6-12,
-	.c1-8,.c2-9,.c3-10,.c4-11,.c5-12,
-	.c1-9,.c2-10,.c3-11,.c4-12,
-	.c1-10,.c2-11,.c3-12,
-	.c1-11,.c2-12,
-	.c1-12	{
-		display: block;
-		float: none;
-		margin-left: 0;
-		width: auto;
-	}
-	.row {
-		margin-left: 0;
+@media only screen and #{$cg-xs-mq} {
+	// Only need generate this output if xs wasn't the default.
+	@if $cg-default-size-prefix != 'xs' {
+		@include _cg-generate-for-size('xs');
 	}
 }
 

--- a/sass/grid.scss
+++ b/sass/grid.scss
@@ -127,6 +127,7 @@ $_cg-default-size-map: map-get($_cg-size-map, $cg-default-size-prefix);
 @mixin cg-grid-width-for-size($size-prefix) {
 	$_map: map-get($_cg-size-map, $size-prefix);
 	$_width: if($cg-use-border-box, map-get($_map, grid-total-width), map-get($_map, grid-inner-width));
+	width: $_width;
 }
 
 @mixin cg-gutters($gutter) {

--- a/sass/grid.scss
+++ b/sass/grid.scss
@@ -98,15 +98,15 @@ $_cg-default-size-map: map-get($_cg-size-map, $cg-default-size-prefix);
 
 /** grid foundation
  -------------------------------------------------- */
-.grid {
+.cg-grid {
 	margin: 0 auto;
 }
 
 /* fluid media */
-.row img,
-.row object,
-.row embed,
-.row video {
+.cg-row img,
+.cg-row object,
+.cg-row embed,
+.cg-row video {
 	max-width: 100%;
 }
 
@@ -144,11 +144,11 @@ $_cg-default-size-map: map-get($_cg-size-map, $cg-default-size-prefix);
 
 	@if($size-prefix == 'xs') {
 		// --- The "xs" size is special and has unique output.
-		.grid {
+		.cg-grid {
 			@include cg-gutters(map-get($_map, grid-gutter));
 			width: auto;
 		}
-		.grid,
+		.cg-grid,
 		.c1,.c2,.c3,.c4,.c5,.c6,.c7,.c8,.c9,.c10,.c11,.c12,
 		.c1-2,.c2-3,.c3-4,.c4-5,.c5-6,.c6-7,.c7-8,.c8-9,.c9-10,.c10-11,.c11-12,
 		.c1-3,.c2-4,.c3-5,.c4-6,.c5-7,.c6-8,.c7-9,.c8-10,.c9-11,.c10-12,
@@ -166,14 +166,14 @@ $_cg-default-size-map: map-get($_cg-size-map, $cg-default-size-prefix);
 			margin-left: 0;
 			width: auto;
 		}
-		.row {
+		.cg-row {
 			margin-left: 0;
 		}
 		// --- (end 'xs' generation)
 
 	} @else {
 		// --- The rest of the sizes use the routine below.
-		.grid {
+		.cg-grid {
 			@include cg-gutters(map-get($_map, grid-gutter));
 			width: map-get($_map, grid-inner-width);
 		}
@@ -252,7 +252,7 @@ $_cg-default-size-map: map-get($_cg-size-map, $cg-default-size-prefix);
 
 		/* 	Accounts for extra margin on first column
 			This value should change a negative margin of whatever your gutter width is. */
-		.row {
+		.cg-row {
 			@include cg-row(map-get($_map, col-margins));
 		}
 		// --- (end non-'xs' code generation)
@@ -328,7 +328,7 @@ $_cg-default-size-map: map-get($_cg-size-map, $cg-default-size-prefix);
 [class*=c10-] .offset1:first-child,
 [class*=c11-] .offset1:first-child,
 [class*=c12-] .offset1:first-child,
-.row .row {
+.cg-row .cg-row {
 	margin-left: 0;
 }
 
@@ -344,15 +344,15 @@ $_cg-default-size-map: map-get($_cg-size-map, $cg-default-size-prefix);
 /* Row offsetfix
 Uses variation of Nicolas Gallagher's Micro offsetfix.
 http://nicolasgallagher.com/micro-offsetfix-hack/ */
-.row:before,
-.row:after {
+.cg-row:before,
+.cg-row:after {
 	content:"";
 	display:table;
 }
-.row:after {
+.cg-row:after {
 	clear:both;
 }
-.row {
+.cg-row {
 	/* Just in case: make sure that rows offset outside floats. */
 	clear: both;
 	/* For IE 6/7 (trigger hasLayout) */

--- a/sass/grid.scss
+++ b/sass/grid.scss
@@ -59,9 +59,9 @@ $cg-lg-column-width: (($cg-lg-grid-inner-width - (($cg-lg-col-margins * ($cg-col
 $cg-md-column-width: (($cg-md-grid-inner-width - (($cg-md-col-margins * ($cg-column-count - 1)))) / $cg-column-count);
 $cg-sm-column-width: (($cg-sm-grid-inner-width - (($cg-sm-col-margins * ($cg-column-count - 1)))) / $cg-column-count);
 @if $cg-use-border-box {
-	$cg-lg-column-width: ((($cg-lg-grid-inner-width + ($cg-lg-grid-gutter * 2)) - (($cg-lg-col-margins * ($cg-column-count - 1)))) / $cg-column-count);
-	$cg-md-column-width: ((($cg-md-grid-inner-width + ($cg-md-grid-gutter * 2)) - (($cg-md-col-margins * ($cg-column-count - 1)))) / $cg-column-count);
-	$cg-sm-column-width: ((($cg-sm-grid-inner-width + ($cg-sm-grid-gutter * 2)) - (($cg-sm-col-margins * ($cg-column-count - 1)))) / $cg-column-count);
+	$cg-lg-column-width: ((($cg-lg-grid-inner-width + ($cg-lg-grid-gutter * 2)) - (($cg-lg-col-margins * ($cg-column-count - 1)))) / $cg-column-count) !global;
+	$cg-md-column-width: ((($cg-md-grid-inner-width + ($cg-md-grid-gutter * 2)) - (($cg-md-col-margins * ($cg-column-count - 1)))) / $cg-column-count) !global;
+	$cg-sm-column-width: ((($cg-sm-grid-inner-width + ($cg-sm-grid-gutter * 2)) - (($cg-sm-col-margins * ($cg-column-count - 1)))) / $cg-column-count) !global;
 }
 
 /** move vars to a map for dynamic usage

--- a/sass/grid.scss
+++ b/sass/grid.scss
@@ -98,15 +98,15 @@ $_cg-default-size-map: map-get($_cg-size-map, $cg-default-size-prefix);
 
 /** grid foundation
  -------------------------------------------------- */
-.cg-grid {
+.grid {
 	margin: 0 auto;
 }
 
 /* fluid media */
-.cg-row img,
-.cg-row object,
-.cg-row embed,
-.cg-row video {
+.row img,
+.row object,
+.row embed,
+.row video {
 	max-width: 100%;
 }
 
@@ -144,11 +144,11 @@ $_cg-default-size-map: map-get($_cg-size-map, $cg-default-size-prefix);
 
 	@if($size-prefix == 'xs') {
 		// --- The "xs" size is special and has unique output.
-		.cg-grid {
+		.grid {
 			@include cg-gutters(map-get($_map, grid-gutter));
 			width: auto;
 		}
-		.cg-grid,
+		.grid,
 		.c1,.c2,.c3,.c4,.c5,.c6,.c7,.c8,.c9,.c10,.c11,.c12,
 		.c1-2,.c2-3,.c3-4,.c4-5,.c5-6,.c6-7,.c7-8,.c8-9,.c9-10,.c10-11,.c11-12,
 		.c1-3,.c2-4,.c3-5,.c4-6,.c5-7,.c6-8,.c7-9,.c8-10,.c9-11,.c10-12,
@@ -166,14 +166,14 @@ $_cg-default-size-map: map-get($_cg-size-map, $cg-default-size-prefix);
 			margin-left: 0;
 			width: auto;
 		}
-		.cg-row {
+		.row {
 			margin-left: 0;
 		}
 		// --- (end 'xs' generation)
 
 	} @else {
 		// --- The rest of the sizes use the routine below.
-		.cg-grid {
+		.grid {
 			@include cg-gutters(map-get($_map, grid-gutter));
 			width: map-get($_map, grid-inner-width);
 		}
@@ -252,7 +252,7 @@ $_cg-default-size-map: map-get($_cg-size-map, $cg-default-size-prefix);
 
 		/* 	Accounts for extra margin on first column
 			This value should change a negative margin of whatever your gutter width is. */
-		.cg-row {
+		.row {
 			@include cg-row(map-get($_map, col-margins));
 		}
 		// --- (end non-'xs' code generation)
@@ -328,7 +328,7 @@ $_cg-default-size-map: map-get($_cg-size-map, $cg-default-size-prefix);
 [class*=c10-] .offset1:first-child,
 [class*=c11-] .offset1:first-child,
 [class*=c12-] .offset1:first-child,
-.cg-row .cg-row {
+.row .row {
 	margin-left: 0;
 }
 
@@ -344,15 +344,15 @@ $_cg-default-size-map: map-get($_cg-size-map, $cg-default-size-prefix);
 /* Row offsetfix
 Uses variation of Nicolas Gallagher's Micro offsetfix.
 http://nicolasgallagher.com/micro-offsetfix-hack/ */
-.cg-row:before,
-.cg-row:after {
+.row:before,
+.row:after {
 	content:"";
 	display:table;
 }
-.cg-row:after {
+.row:after {
 	clear:both;
 }
-.cg-row {
+.row {
 	/* Just in case: make sure that rows offset outside floats. */
 	clear: both;
 	/* For IE 6/7 (trigger hasLayout) */


### PR DESCRIPTION
This PR includes substantial changes to the _how_ CSS code is generated (for the sake of configurability and encapsulation), but little change to the resulting CSS. Changes include:
- Vars and mixins are new prefixed w/`cg-` to prevent collisions/confusion when using other libraries
- The default size that gets used by browsers that cannot understand media queries is now configurable via `$cg-default-size-prefix` (which accepts the size identifiers `xs`, `sm`, `md`, `lg`) 
- The code that generates grid styles for each size is now generated in a mixin called `_cg-generate-for-size()`. Aside from the `xs` size, it generates code for each using the same routine and replacing various values with the size-specific variables defined early in the script.
- Generated code can now work in `box-sizing:border-box` environment and stay true to configured sizes via new `$cg-use-border-box` toggle. Note that it doesn't _declare_ a value for `box-sizing` (it assumes you've already done that in your project code). For example, with `$cg-use-border-box:true`, `width` property of `.grid` for a given size is set to the value of that size's inner width + padding (gutter) vars. If `$cg-use-border-box:false`, the `width` property of `.grid` is set to inner width.
